### PR TITLE
Fixed getNavigationGroup() return, which was hard-coded

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nuxt.isNuxtApp": false
+}

--- a/src/Pages/SettingsHub.php
+++ b/src/Pages/SettingsHub.php
@@ -13,7 +13,7 @@ class SettingsHub extends Page
 
     public static function getNavigationGroup(): ?string
     {
-        return 'Settings';
+        return trans('filament-settings-hub::messages.group');
     }
 
     public function getTitle(): string


### PR DESCRIPTION
I changed in the file src/Pages/SettingsHub.php:

public static function getNavigationGroup(): ?string
{
    return 'Settings';
}

to:

public static function getNavigationGroup(): ?string
{
    return trans('filament-settings-hub::messages.group');
}

This way the name in the navigation menu was changed to the chosen name.